### PR TITLE
Fix node process not ending in some situations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export const esbuildResolve = ({
   const destroyEsbuild = () => {
     if (esbuildContext) {
       esbuildContext.dispose();
+      esbuild.stop();
       esbuildContext = null;
       esbuildPluginBuild = null;
     }


### PR DESCRIPTION
Sometimes the esbuild child process is not automatically stopped after rollup finishes building. The occurence is somewhat inconsistent. On some systems the process exits fine, while on others it stays idle. The only requirement we noticed is that the `rollup-plugin-esbuild` plugin is used as well.

rollup.config.js:
```js
import esbuild from 'rollup-plugin-esbuild';
import { esbuildResolve } from 'rollup-plugin-esbuild-resolve';

export default {
	input: 'src/index.ts',
	preserveEntrySignatures: 'strict',
	output: {
		format: 'es',
		dir: 'dist',
		preserveModules: true,
	},
	external: [/node_modules/],
	plugins: [
		esbuildResolve({ esbuild: { platform: 'node' } }),
		esbuild({
			exclude: [/node_modules/],
			sourceMap: true,
			minify: true,
			keepNames: true,
			target: 'node2022',
		}),
	],
};
```

The problem is fixed by calling `esbuild.stop()` after `context.dispose()` in the buildEnd hook to close the child process now that it's no longer required.